### PR TITLE
fix(test): stop Node 26's Web Storage globals shadowing jsdom's

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,20 @@ const require = createRequire(import.meta.url);
 const monacoPathParts = require.resolve("monaco-editor").split(sep);
 const sharedNodeModules = monacoPathParts.slice(0, monacoPathParts.lastIndexOf("node_modules") + 1).join(sep);
 
+// Node 26 ships its own `localStorage`/`sessionStorage` globals. Without
+// `--localstorage-file` they read back as `undefined`, and vitest's jsdom
+// environment only copies a jsdom window key onto `globalThis` when the key
+// isn't there already or sits on its hardcoded allowlist — that list covers
+// `Storage`, not the two instances. So Node's empty built-ins win and every
+// test touching `window.localStorage` fails with "Cannot read properties of
+// undefined (reading 'removeItem')". Turning the built-ins off in the test
+// workers lets jsdom install its real Storage.
+//
+// Probed rather than passed unconditionally: the flag only exists on Node
+// versions that have Web Storage, and CI still runs Node 22. `in` doesn't
+// invoke the getter, so this doesn't trip Node's ExperimentalWarning.
+const testExecArgv = "localStorage" in globalThis ? ["--no-experimental-webstorage"] : [];
+
 export default defineConfig({
   plugins: [vue()],
   root: resolve(__dirname, "src"),
@@ -76,5 +90,6 @@ export default defineConfig({
     // useIsNarrow / responsive composables don't crash with "matchMedia
     // is not a function" the moment they hit onMounted.
     setupFiles: [resolve(__dirname, "test/vitest-setup.ts")],
+    execArgv: testExecArgv,
   },
 });


### PR DESCRIPTION
## Problem

On **Node 26** the entire jsdom suite fails — 172 tests across 14 files die with:

```
TypeError: Cannot read properties of undefined (reading 'removeItem')
  window.localStorage.removeItem("strideterm-notifications-v2");
```

CI doesn't catch it because CI still runs Node 22.

## Cause

Node 26 defines `localStorage`/`sessionStorage` on `globalThis`. Without `--localstorage-file` the getter returns `undefined` and emits an `ExperimentalWarning`.

vitest's jsdom environment copies a jsdom window key onto `globalThis` only when the key isn't already there or is on its hardcoded allowlist (`getWindowKeys`: `if (k in global) return keysArray.includes(k)`). That allowlist contains `Storage`, but not `localStorage`/`sessionStorage`. So Node's empty built-ins win and jsdom's real Storage is never installed.

Patching it from `test/vitest-setup.ts` isn't possible either — vitest points `document.defaultView` at the global object itself, so the real jsdom window is unreachable from test code.

vitest 4.1.10 is the latest release; there is no upstream fix to pick up.

## Fix

Turn the built-ins off in the test workers via `test.execArgv` so jsdom installs its own Storage. The flag is probed rather than passed unconditionally, since it only exists on Node versions that ship Web Storage and CI is still on Node 22 (`in` doesn't invoke the getter, so it doesn't trip the warning).

## Verification

Full `npm test` on Node 26 (v26.5.1), which was fully broken before:

- UI: **133 files / 1336 tests passed**
- Backend: **84 files / 2151 tests passed** (4 skipped)

CI on this PR additionally proves the Node 22 path — the guard must skip the flag there.