### PR TITLE
fix(ci): give nightly's lint step the same heap headroom as CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,19 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+    ignore:
+      # TypeScript 7 ships without a programmatic compiler API —
+      # `require("typescript")` exposes only `version`/`versionMajorMinor` — and
+      # typescript-eslint's type-aware rules are built straight against that API.
+      # So its peer range pins `typescript ">=4.8.4 <6.1.0"` (same on the canary
+      # channel) and a major bump can't even install: `npm ci` dies on ERESOLVE
+      # before any of our code is compiled. Upstream closed the support request
+      # as not-planned ("there is nothing we can do about this until TS 7
+      # provides an API"); that API is expected in TypeScript 7.1.
+      # Tracking: typescript-eslint/typescript-eslint#10940.
+      # Drop this ignore once typescript-eslint supports TypeScript 7.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions — keep CI actions up to date (monthly is fine)
   - package-ecosystem: github-actions

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,6 +41,11 @@ jobs:
         continue-on-error: true
       - name: Lint (includes security static analysis)
         run: npm run lint
+        # Same heap headroom as ci.yml. eslint's type-aware + security static
+        # analysis exceeds Node's default ~2GB old-space and aborts with
+        # exit 134; without this the nightly fails while CI stays green.
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
       - run: npm test
       - run: npm run build
 


### PR DESCRIPTION
Two bits of CI hygiene.

## 1. Nightly Build has failed 8 nights running

Today's run (`16f299e`) died on `macos-14`:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
sh: line 1: 14294 Abort trap: 6   eslint .
##[error]Process completed with exit code 134
```

That is the exact failure `ci.yml` already documents and fixes:

```yaml
- name: Lint (includes security static analysis)
  run: npm run lint
  # eslint's type-aware + security static analysis exceeds Node's default
  # ~2GB old-space heap on the macOS runner (OOM, exit 134) […]
  env:
    NODE_OPTIONS: --max-old-space-size=4096
```

`nightly.yml` never got the same `env`, so CI stayed green while the nightly quietly rotted. It alternated between `macos-14` and `ubuntu-latest` depending on which runner was tightest. (The earlier runs in that streak failed on the `npm audit --audit-level=high` gate instead — already fixed on master by `3a013d9` and `16f299e`.)

## 2. Stop dependabot re-opening the TypeScript 7 bump (#145)

PR #145 (`typescript` 6.0.3 → 7.0.2) cannot be merged, and no change on our side fixes it:

- TypeScript 7.0 **ships without a programmatic compiler API** — `require("typescript")` exposes only `version` and `versionMajorMinor`. Microsoft: *"While TypeScript 7.0 is here, it does not ship with an API. We expect TypeScript 7.1 to ship with a new (and different) API."*
- typescript-eslint's type-aware rules are built directly against that API, so its peer range pins `typescript ">=4.8.4 <6.1.0"` — the **same range on its canary channel** (`8.65.1-alpha.20`). `npm ci` dies on ERESOLVE before any of our code is compiled.
- Upstream closed the support request ([typescript-eslint#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518)) as **not planned**. Maintainer: *"typescript-eslint isn't compatible with TS 7 at this time, because there is no TS 7 API at this time. There is nothing we can do about this until TS 7 provides an API."*
- Tracking issue [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940) is open, unassigned, no milestone, no linked PR.

So the major is ignored until then, with the reasoning recorded in `dependabot.yml`. Minor/patch TypeScript updates and all security updates are unaffected.

## Verification

Both files re-parsed with a YAML parser and the values asserted:

- `nightly.yml` → lint step `env` = `{"NODE_OPTIONS":"--max-old-space-size=4096"}`
- `dependabot.yml` → npm `ignore` = `[{"dependency-name":"typescript","update-types":["version-update:semver-major"]}]`

The nightly change only takes real effect on the next scheduled run (or a manual `workflow_dispatch`).