### PR TITLE
fix(deps): clear newly published high audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1949,9 +1949,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1969,9 +1966,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1989,9 +1983,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2009,9 +2000,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2029,9 +2017,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2049,9 +2034,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5577,9 +5559,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -6412,9 +6394,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -7032,9 +7014,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7056,9 +7035,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7080,9 +7056,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7104,9 +7077,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7670,9 +7640,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9506,9 +9476,9 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9911,9 +9881,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -204,8 +204,12 @@
   "overrides": {
     "dompurify": "3.4.12",
     "uuid": "^14.0.0",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.5",
     "hono": "4.12.31",
+    "ip-address": "^10.4.0",
+    "tar": "^7.5.22",
+    "undici@6": "^6.28.0",
+    "undici@7": "^7.29.0",
     "@hono/node-server": "^2.0.5",
     "tmp": "^0.2.6",
     "qs": "^6.15.2",


### PR DESCRIPTION
## Why master went red

CI on `327489e` failed the `npm audit --audit-level=high` gate. **This was not the vite bump it landed on** — three high advisories were published after the previous green run:

| package | advisory | issue |
|---|---|---|
| `fast-uri` | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) | host confusion via backslash authority introducer |
| `ip-address` | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) + 2 more | leading-zero octal, CIDR suffix and NAT64 misclassification → SSRF / trust-boundary bypass |
| `undici` | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) + 7 more | response desynchronization, CRLF injection, cache disclosure |

## Fix

All three are patched **inside their current major**, so no major jumps:

- `fast-uri` → 3.1.5 (the existing `^3.1.4` override was pinned by the lock)
- `ip-address` → 10.4.0 (reaches us via `@modelcontextprotocol/sdk` → `express-rate-limit`, a prod dep)
- `undici` → 6.28.0 **and** 7.29.0 — two pinned majors are needed because `node-gyp` (via `electron-builder`) pulls 6.x while `@electron/get` (via `electron`) pulls 7.x. Follows the existing `brace-expansion@1/@2/@5` pattern in `overrides`. jsdom's `undici@8.9.0` isn't in the vulnerable range and is left alone.
- `tar` → 7.5.22 (moderate, in-major, already in the same install)

## One thing deliberately left out

Bumping `hono` 4.12.31 → 4.12.34 would clear the remaining moderate ReDoS in its CORS middleware. I did **not** do it: `scripts/check-package-age.mts` blocks it in `pre-commit`, because 4.12.34 was published today.

```
FAILED: 1 package(s) published less than 1 days ago:
  hono@4.12.34 — published 2026-08-03 (0d ago)
```

That guard exists exactly to keep same-day releases out of the tree, so bypassing it with `--allow=` for a *moderate* seemed like the wrong trade. Worth a follow-up once it ages past the threshold — hono sits on the remote server's request path. The gate is `high`, so the three remaining moderates (`hono` plus its two dependents) don't block CI.

## Verification

- `npm audit --audit-level=high` → exit 0
- `npm run typecheck` → exit 0
- `npm test` → **1336 UI + 2151 backend tests passing** (4 skipped)
- Resolved tree confirmed: `fast-uri@3.1.5`, `ip-address@10.4.0`, `undici@6.28.0` / `7.29.0` / `8.9.0`, `tar@7.5.22`