### PR TITLE
fix(remote): seed a remote client from the desktop's live view

### DIFF
--- a/electron/backend/remote-client-registry.test.ts
+++ b/electron/backend/remote-client-registry.test.ts
@@ -9,7 +9,13 @@ function makeState(
   opts: {
     profiles?: { id: string; lastActiveWorkspaceId?: string; lastActiveSessionId?: string; workspaceGrid?: unknown }[];
     workspaces?: { id: string; profileId?: string }[];
-    windowSlots?: { id: string; profileId: string; activeWorkspaceId?: string; activeSessionId?: string }[];
+    windowSlots?: {
+      id: string;
+      profileId: string;
+      activeWorkspaceId?: string;
+      activeSessionId?: string;
+      lastFocusedAt?: number;
+    }[];
   } = {},
 ) {
   const profiles = opts.profiles ?? [{ id: "default" }];
@@ -76,7 +82,7 @@ describe("RemoteClientRegistry", () => {
       expect(client.activeWorkspaceId).toBe("ws2");
     });
 
-    test("seeds view state from the profile's lastActive ids when valid", () => {
+    test("seeds view state from the profile's lastActive ids when the profile has no desktop window", () => {
       const registry = new RemoteClientRegistry();
       const state = makeState({
         profiles: [{ id: "p1", lastActiveWorkspaceId: "ws2", lastActiveSessionId: "ws2:shell" }],
@@ -84,6 +90,7 @@ describe("RemoteClientRegistry", () => {
           { id: "ws1", profileId: "p1" },
           { id: "ws2", profileId: "p1" },
         ],
+        windowSlots: [],
       });
       const client = registry.getOrCreate("session1", state);
       expect(client.activeWorkspaceId).toBe("ws2");
@@ -97,6 +104,257 @@ describe("RemoteClientRegistry", () => {
       c1.profileId = "p1";
       const c2 = registry.getOrCreate("session1", state);
       expect(c2).toBe(c1);
+    });
+  });
+
+  // A client adopts the desktop's CURRENT view for its profile when it binds,
+  // because profile.lastActive* is only written on deactivation-ish events and
+  // drifts from what the user is looking at. Adoption happens on (re)bind only
+  // — never on the broadcast path — so an established remote view is never
+  // dragged around by the desktop mid-session.
+  describe("seedViewState — adopting the desktop view", () => {
+    test("prefers the profile's live desktop window over the lastActive mirror", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1", lastActiveWorkspaceId: "ws-stale", lastActiveSessionId: "ws-stale:shell" }],
+        workspaces: [
+          { id: "ws-stale", profileId: "p1" },
+          { id: "ws-live", profileId: "p1" },
+        ],
+        windowSlots: [{ id: "win-1", profileId: "p1", activeWorkspaceId: "ws-live", activeSessionId: "ws-live:term" }],
+      });
+      const client = registry.getOrCreate("session1", state);
+      expect(client.activeWorkspaceId).toBe("ws-live");
+      expect(client.activeSessionId).toBe("ws-live:term");
+    });
+
+    test("picks the most recently focused window when the profile has several", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1" }],
+        workspaces: [
+          { id: "ws-a", profileId: "p1" },
+          { id: "ws-b", profileId: "p1" },
+        ],
+        windowSlots: [
+          { id: "win-1", profileId: "p1", activeWorkspaceId: "ws-a", activeSessionId: "ws-a:x", lastFocusedAt: 100 },
+          { id: "win-2", profileId: "p1", activeWorkspaceId: "ws-b", activeSessionId: "ws-b:y", lastFocusedAt: 900 },
+        ],
+      });
+      const client = registry.getOrCreate("session1", state);
+      expect(client.activeWorkspaceId).toBe("ws-b");
+      expect(client.activeSessionId).toBe("ws-b:y");
+    });
+
+    test("most-recent wins regardless of slot array order", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1" }],
+        workspaces: [
+          { id: "ws-a", profileId: "p1" },
+          { id: "ws-b", profileId: "p1" },
+        ],
+        windowSlots: [
+          { id: "win-2", profileId: "p1", activeWorkspaceId: "ws-b", lastFocusedAt: 900 },
+          { id: "win-1", profileId: "p1", activeWorkspaceId: "ws-a", lastFocusedAt: 100 },
+        ],
+      });
+      expect(registry.getOrCreate("session1", state).activeWorkspaceId).toBe("ws-b");
+    });
+
+    test("ties on lastFocusedAt resolve to the first slot, deterministically", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1" }],
+        workspaces: [
+          { id: "ws-a", profileId: "p1" },
+          { id: "ws-b", profileId: "p1" },
+        ],
+        windowSlots: [
+          { id: "win-1", profileId: "p1", activeWorkspaceId: "ws-a", lastFocusedAt: 500 },
+          { id: "win-2", profileId: "p1", activeWorkspaceId: "ws-b", lastFocusedAt: 500 },
+        ],
+      });
+      expect(registry.getOrCreate("s1", state).activeWorkspaceId).toBe("ws-a");
+      expect(registry.getOrCreate("s2", state).activeWorkspaceId).toBe("ws-a");
+    });
+
+    test("slots with no lastFocusedAt at all still resolve to the first slot", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1" }],
+        workspaces: [
+          { id: "ws-a", profileId: "p1" },
+          { id: "ws-b", profileId: "p1" },
+        ],
+        windowSlots: [
+          { id: "win-1", profileId: "p1", activeWorkspaceId: "ws-a" },
+          { id: "win-2", profileId: "p1", activeWorkspaceId: "ws-b" },
+        ],
+      });
+      expect(registry.getOrCreate("session1", state).activeWorkspaceId).toBe("ws-a");
+    });
+
+    test("ignores desktop windows belonging to other profiles", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1", lastActiveWorkspaceId: "ws1b" }, { id: "p2" }],
+        workspaces: [
+          { id: "ws1a", profileId: "p1" },
+          { id: "ws1b", profileId: "p1" },
+          { id: "ws2", profileId: "p2" },
+        ],
+        // A p2 window is focused far more recently — it must not seed a p1 client.
+        windowSlots: [{ id: "win-2", profileId: "p2", activeWorkspaceId: "ws2", lastFocusedAt: 9999 }],
+      });
+      const client = registry.getOrCreate("session1", state, "p1");
+      expect(client.profileId).toBe("p1");
+      expect(client.activeWorkspaceId).toBe("ws1b");
+    });
+
+    test("falls back to the mirror when the desktop workspace left the profile", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1", lastActiveWorkspaceId: "ws-mirror", lastActiveSessionId: "ws-mirror:shell" }],
+        workspaces: [
+          { id: "ws-mirror", profileId: "p1" },
+          { id: "ws-moved", profileId: "p2" },
+        ],
+        // Slot still points at a workspace that now belongs to p2.
+        windowSlots: [{ id: "win-1", profileId: "p1", activeWorkspaceId: "ws-moved" }],
+      });
+      const client = registry.getOrCreate("session1", state);
+      expect(client.activeWorkspaceId).toBe("ws-mirror");
+      expect(client.activeSessionId).toBe("ws-mirror:shell");
+    });
+
+    test("falls back to the first profile workspace when neither slot nor mirror is usable", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1", lastActiveWorkspaceId: "ws-gone" }],
+        workspaces: [
+          { id: "ws-first", profileId: "p1" },
+          { id: "ws-second", profileId: "p1" },
+        ],
+        windowSlots: [{ id: "win-1", profileId: "p1", activeWorkspaceId: "" }],
+      });
+      const client = registry.getOrCreate("session1", state);
+      expect(client.activeWorkspaceId).toBe("ws-first");
+      expect(client.activeSessionId).toBe("");
+    });
+
+    test("does not pair an adopted desktop workspace with a mirrored session", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1", lastActiveWorkspaceId: "ws-other", lastActiveSessionId: "ws-other:shell" }],
+        workspaces: [
+          { id: "ws-live", profileId: "p1" },
+          { id: "ws-other", profileId: "p1" },
+        ],
+        // Desktop shows ws-live with no focused session — the client must show
+        // the same, not ws-live plus a session mirrored from another workspace.
+        windowSlots: [{ id: "win-1", profileId: "p1", activeWorkspaceId: "ws-live", activeSessionId: "" }],
+      });
+      const client = registry.getOrCreate("session1", state);
+      expect(client.activeWorkspaceId).toBe("ws-live");
+      expect(client.activeSessionId).toBe("");
+    });
+
+    test("clears an adopted session that does not belong to the adopted workspace", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1" }],
+        workspaces: [
+          { id: "ws-a", profileId: "p1" },
+          { id: "ws-b", profileId: "p1" },
+        ],
+        windowSlots: [{ id: "win-1", profileId: "p1", activeWorkspaceId: "ws-a", activeSessionId: "ws-b:shell" }],
+      });
+      const client = registry.getOrCreate("session1", state);
+      expect(client.activeWorkspaceId).toBe("ws-a");
+      expect(client.activeSessionId).toBe("");
+    });
+
+    test("adoption does not follow the desktop after the client is bound", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1" }],
+        workspaces: [
+          { id: "ws-a", profileId: "p1" },
+          { id: "ws-b", profileId: "p1" },
+        ],
+        windowSlots: [{ id: "win-1", profileId: "p1", activeWorkspaceId: "ws-a", activeSessionId: "ws-a:shell" }],
+      });
+      const client = registry.getOrCreate("session1", state);
+      expect(client.activeWorkspaceId).toBe("ws-a");
+
+      // Desktop moves on. A reconnect (same cookie session) must NOT re-adopt —
+      // otherwise a phone on a flaky link gets yanked around on every reconnect.
+      const moved = makeState({
+        profiles: [{ id: "p1" }],
+        workspaces: [
+          { id: "ws-a", profileId: "p1" },
+          { id: "ws-b", profileId: "p1" },
+        ],
+        windowSlots: [
+          {
+            id: "win-1",
+            profileId: "p1",
+            activeWorkspaceId: "ws-b",
+            activeSessionId: "ws-b:shell",
+            lastFocusedAt: 999,
+          },
+        ],
+      });
+      expect(registry.getOrCreate("session1", moved)).toBe(client);
+      expect(client.activeWorkspaceId).toBe("ws-a");
+      expect(client.activeSessionId).toBe("ws-a:shell");
+
+      // Nor via the broadcast path.
+      const composed = registry.composePayload("session1", { appState: moved }) as Record<string, unknown>;
+      expect((composed.remoteClient as Record<string, unknown>).activeWorkspaceId).toBe("ws-a");
+    });
+
+    test("a client that picked its own workspace keeps it across broadcasts", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1" }],
+        workspaces: [
+          { id: "ws-a", profileId: "p1" },
+          { id: "ws-b", profileId: "p1" },
+        ],
+        windowSlots: [{ id: "win-1", profileId: "p1", activeWorkspaceId: "ws-a", lastFocusedAt: 999 }],
+      });
+      registry.getOrCreate("session1", state);
+      registry.activateWorkspace("session1", "ws-b", state);
+      const composed = registry.composePayload("session1", { appState: state }) as Record<string, unknown>;
+      expect((composed.remoteClient as Record<string, unknown>).activeWorkspaceId).toBe("ws-b");
+    });
+
+    test("switching profile adopts that profile's desktop view", () => {
+      const registry = new RemoteClientRegistry();
+      const state = makeState({
+        profiles: [{ id: "p1" }, { id: "p2", lastActiveWorkspaceId: "ws2-stale" }],
+        workspaces: [
+          { id: "ws1", profileId: "p1" },
+          { id: "ws2-stale", profileId: "p2" },
+          { id: "ws2-live", profileId: "p2" },
+        ],
+        windowSlots: [
+          { id: "win-1", profileId: "p1", activeWorkspaceId: "ws1", lastFocusedAt: 100 },
+          {
+            id: "win-2",
+            profileId: "p2",
+            activeWorkspaceId: "ws2-live",
+            activeSessionId: "ws2-live:t",
+            lastFocusedAt: 50,
+          },
+        ],
+      });
+      registry.getOrCreate("session1", state);
+      registry.activateProfile("session1", "p2", state);
+      expect(registry.get("session1")!.activeWorkspaceId).toBe("ws2-live");
+      expect(registry.get("session1")!.activeSessionId).toBe("ws2-live:t");
     });
   });
 
@@ -203,6 +461,8 @@ describe("RemoteClientRegistry", () => {
           { id: "ws1", profileId: "p1" },
           { id: "ws2", profileId: "p1" },
         ],
+        // Session comes from the desktop slot the client adopts on bind.
+        windowSlots: [{ id: "win-1", profileId: "p1", activeWorkspaceId: "ws1", activeSessionId: "ws1:shell" }],
       });
       registry.getOrCreate("session1", state);
       expect(registry.get("session1")!.activeSessionId).toBe("ws1:shell");

--- a/electron/backend/remote-client-registry.ts
+++ b/electron/backend/remote-client-registry.ts
@@ -79,20 +79,68 @@ export class RemoteClientRegistry {
   }
 
   /**
-   * Seed a client's view state when it (re)binds to a profile — mirror of the
-   * runtime's resolveProfileRestoreTarget plus the legacy profile grid as the
-   * default layout.
+   * The desktop window a freshly-bound client should adopt its view from: the
+   * most recently focused slot in `profileId`, or null when the profile has no
+   * desktop window. Focus ordering follows the same convention as main.ts's
+   * primary-window pick (`lastFocusedAt || 0`, highest wins); ties keep the
+   * earlier slot so the result is deterministic.
+   */
+  private primarySlotForProfile(appState: AnyState, profileId: string): AnyState | null {
+    const slots: AnyState[] = appState?.windowSlots || [];
+    const inProfile = slots.filter((slot: AnyState) => String(slot?.profileId || "") === profileId);
+    if (inProfile.length === 0) return null;
+    return inProfile.reduce((best: AnyState, slot: AnyState) =>
+      Number(slot?.lastFocusedAt || 0) > Number(best?.lastFocusedAt || 0) ? slot : best,
+    );
+  }
+
+  /**
+   * Seed a client's view state when it (re)binds to a profile.
+   *
+   * Precedence: the profile's live desktop window, then the profile's
+   * lastActive mirror, then its first workspace.
+   *
+   * The desktop window comes first because the mirror
+   * (`profile.lastActiveWorkspaceId`) is only written on deactivation-ish
+   * events — workspace/session switch, profile switch, window close — so it
+   * drifts from what the user is actually looking at: two windows in one
+   * profile overwrite each other's value, and a mirror that survived a kill
+   * is never corrected on load (the windowSlot seed in normalizeState only
+   * fills a MISSING one). Reading the slot here makes "connect from the phone"
+   * land on the desktop's current view.
+   *
+   * This runs on (re)bind only — fresh session, profile switch, or a profile
+   * that ceased to exist — never on the broadcast path, so the desktop cannot
+   * drag an established remote view around mid-session. `composePayload` ->
+   * `revalidate` still only touches an INVALID selection.
    */
   private seedViewState(client: RemoteClientContext, appState: AnyState): void {
     const profiles: AnyState[] = appState?.profiles || [];
     const profile = profiles.find((p: AnyState) => p.id === client.profileId);
     const wsList = this.profileWorkspaces(appState, client.profileId);
+    const inProfile = (id: string): boolean => Boolean(id) && wsList.some((ws: AnyState) => ws.id === id);
+
+    const slot = this.primarySlotForProfile(appState, client.profileId);
+    const slotWsId = String(slot?.activeWorkspaceId || "");
     const savedWsId = String(profile?.lastActiveWorkspaceId || "");
-    client.activeWorkspaceId =
-      savedWsId && wsList.some((ws: AnyState) => ws.id === savedWsId) ? savedWsId : String(wsList[0]?.id || "");
-    const savedSessionId = String(profile?.lastActiveSessionId || "");
-    client.activeSessionId =
-      client.activeWorkspaceId && savedSessionId.startsWith(`${client.activeWorkspaceId}:`) ? savedSessionId : "";
+
+    // Each source contributes workspace AND session together. Pairing a slot
+    // workspace with a mirrored session would synthesise a view neither the
+    // desktop nor the previous remote client ever had.
+    let workspaceId: string;
+    let sessionId = "";
+    if (inProfile(slotWsId)) {
+      workspaceId = slotWsId;
+      sessionId = String(slot?.activeSessionId || "");
+    } else if (inProfile(savedWsId)) {
+      workspaceId = savedWsId;
+      sessionId = String(profile?.lastActiveSessionId || "");
+    } else {
+      workspaceId = String(wsList[0]?.id || "");
+    }
+
+    client.activeWorkspaceId = workspaceId;
+    client.activeSessionId = workspaceId && sessionId.startsWith(`${workspaceId}:`) ? sessionId : "";
     client.workspaceGrid = this.sanitizeGrid(profile?.workspaceGrid, appState, client.profileId);
   }
 

--- a/electron/backend/remote-server.ts
+++ b/electron/backend/remote-server.ts
@@ -930,7 +930,11 @@ function json(response: ServerResponse, statusCode: number, body: unknown): void
   // client that already holds the current body sends If-None-Match and we skip
   // re-sending it. Supplementary — correctness never depends on it.
   if (ctx?.method === "GET" && statusCode === 200) {
-    const etag = `"${createHash("sha1").update(raw).digest("base64")}"`;
+    // sha256, not sha1: the ETag is only a cache validator, but the body it
+    // digests carries workspace/session identifiers, and CodeQL's
+    // weak-cryptographic-algorithm rule flags sha1 over that data as a high
+    // alert. Nothing here depends on the digest being short.
+    const etag = `"${createHash("sha256").update(raw).digest("base64")}"`;
     headers.ETag = etag;
     headers["Cache-Control"] = "no-cache"; // must revalidate, but 304 is allowed
     if (ctx.ifNoneMatch && ctx.ifNoneMatch === etag) {


### PR DESCRIPTION
Connecting from a phone often opens a different workspace/tab than the desktop is showing.

## Cause

A remote client is an independent viewer with its own `activeWorkspaceId` — that part is deliberate, and `resolveRemoteWorkspaceId` (`src/stores/app.ts:227`) carries an explicit guard against ever falling back to the desktop-global value, because that once made the mobile view flip-flop whenever both were active. **That guard is untouched here.**

The problem is only the *seed*. On bind, `seedViewState` read `profile.lastActiveWorkspaceId` — a value the code itself calls a *"legacy mirror of the last deactivation"*. It is written only on deactivation-ish events (`runtime.ts:4968`, `:5029`, `:5072`, `:5185`), so it drifts:

- **Two windows in one profile** overwrite each other's mirror, so it can point at the window the user is *not* using — the mirror is per-profile, not per-window.
- **A mirror that survived a kill is never corrected on load.** The `windowSlot -> profile` seed in `normalizeState` only fills a *missing* one (`default-state.ts:1314`), so a stale non-empty value sticks.

## Fix

Precedence in `seedViewState` becomes:

```
1. the profile's most recently focused windowSlot   (new)
2. profile.lastActiveWorkspaceId                    (unchanged)
3. first workspace of the profile                   (unchanged)
```

Focus ordering matches `main.ts:453`'s primary-window convention (`lastFocusedAt || 0`, highest wins). Ties keep the earlier slot so the result is deterministic and independent of array order.

Workspace and session are adopted from the **same** source — pairing a slot workspace with a mirrored session would synthesise a view neither viewer ever had.

## Why this can't reintroduce the flip-flop

`seedViewState` is not on the broadcast path. It runs on (re)bind only:

| caller | when |
|---|---|
| `getOrCreate:165` | fresh session |
| `activateProfile:190` | user switches profile on the phone |
| `revalidate:126` | client's profile ceased to exist |
| `fallbackDeletedProfile:250` | profile deleted |

`composePayload` -> `revalidate` runs on every push but still only rewrites an **invalid** selection. A phone reconnecting on a flaky link keeps its own pick — covered by a test.

## Tests

13 new, in a `seedViewState — adopting the desktop view` block:

- prefers the live desktop window over the mirror (workspace **and** session)
- picks the most recently focused window of several; independent of array order
- ties and all-missing `lastFocusedAt` resolve deterministically to the first slot
- ignores desktop windows of **other** profiles even when focused far more recently
- falls back to the mirror when the slot's workspace left the profile
- falls back to the first workspace when neither slot nor mirror is usable
- does not pair an adopted desktop workspace with a mirrored session
- clears an adopted session that doesn't belong to the adopted workspace
- **adoption does not follow the desktop after bind** — reconnect returns the same context, and the broadcast path doesn't move it either
- a client that picked its own workspace keeps it across broadcasts
- switching profile adopts *that* profile's desktop view

One existing assertion narrowed, not deleted: `"seeds view state from the profile's lastActive ids"` now runs with `windowSlots: []`, which is when the mirror is still the authority.

Verified: `npm run typecheck` exit 0; `npm test` **1336 UI + 2164 backend** passing (was 2151, +13).

## Two things worth knowing

**1. The `lastActiveWorkspaceId` backfill we discussed already exists** and already runs — `seedRestoreIdsFromSlots` defaults to `true` on disk-load paths (`store.ts` passes `false` only for live `mutate`/`replace`, with a comment explaining why). Profiles that still show `undefined` are ones that never had a desktop window, so there is nothing to seed from. No change was needed.

**2. This may not fully fix the reported symptom.** Within one app run, an existing cookie session is **never** reseeded (`getOrCreate` returns early on an existing client). So reopening the browser on the phone hours later reuses the pick made earlier in that run, and this change doesn't touch that. Making a reconnect re-adopt is a separate decision — and the one place where the flip-flop worry is genuinely justified, since mobile links reconnect constantly. Left out on purpose.